### PR TITLE
Expand voting schema with reaction catalog and counters

### DIFF
--- a/docs/reactions.md
+++ b/docs/reactions.md
@@ -1,0 +1,17 @@
+# Reactions Schema
+
+The voting service stores emoji reactions and precomputed rollups for fast deal ranking.
+
+## Tables
+
+- **reaction_catalog** – allowed emojis with display labels, polarity (`positive`, `negative`, `neutral`), default weights and active flags.
+- **reactions** – individual reaction events with user and device context, user weight multipliers and idempotency keys. Rows are soft-deleted via `deleted_at` and carry abuse signals such as `ip_hash` and `user_risk_score`.
+- **deal_user_reaction_snapshots** – one row per `(deal_id, user_id)` capturing the current polarity, total emoji count by that user on the deal and `last_action_at` for conflict resolution.
+- **deal_reaction_counters** – aggregate totals per deal broken out by polarity and per-emoji counts plus a cached `deal_exists` flag for orphan detection.
+- **deal_reaction_hourly_counters** – time bucketed rollups (hourly) used for velocity calculations.
+- **deal_scores** – derived fields like `hot_score`, `last_scored_at` and `is_hot` system tag to surface trending deals without recomputation on read.
+- **reaction_events** – append-only audit log for add/remove/clear/switch actions.
+
+## Indexing
+
+Indexes on the `reactions` table support hot paths such as lookups by deal, user, `(deal, created_at)` and `(deal, emoji)`. Hourly counters include an index on `(deal_id, bucket_start)` for fast trend queries.

--- a/schemas/postgres/votes.sql
+++ b/schemas/postgres/votes.sql
@@ -2,13 +2,93 @@
 CREATE DATABASE voting_service;
 \c voting_service;
 
-CREATE TYPE vote_type AS ENUM ('upvote','downvote');
+-- Reaction catalog stores supported emoji and their properties
+CREATE TYPE reaction_polarity AS ENUM ('positive','negative','neutral');
 
-CREATE TABLE votes (
+CREATE TABLE reaction_catalog (
+    emoji TEXT PRIMARY KEY,          -- canonical emoji code
+    label TEXT NOT NULL,             -- display label
+    polarity reaction_polarity NOT NULL,
+    default_weight NUMERIC(4,2) NOT NULL DEFAULT 1.0,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE
+);
+
+-- Individual reaction events (source of truth)
+CREATE TABLE reactions (
+    id BIGSERIAL PRIMARY KEY,
+    deal_id BIGINT NOT NULL,
+    user_id BIGINT NOT NULL,
+    emoji TEXT NOT NULL REFERENCES reaction_catalog(emoji),
+    polarity reaction_polarity NOT NULL,
+    weight NUMERIC(6,3) NOT NULL,           -- effective weight after multipliers
+    user_weight_multiplier NUMERIC(4,2) DEFAULT 1.0,
+    device_id TEXT,
+    app_version TEXT,
+    ip_hash TEXT,
+    user_risk_score NUMERIC(4,2),
+    idempotency_key UUID NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    deleted_at TIMESTAMPTZ,
+    shadow_banned BOOLEAN DEFAULT FALSE
+);
+
+-- Snapshot per (deal,user) storing current direction and counts
+CREATE TABLE deal_user_reaction_snapshots (
     deal_id BIGINT,
     user_id BIGINT,
-    type vote_type NOT NULL,
-    emoji TEXT,
-    created_at TIMESTAMPTZ DEFAULT NOW(),
-    PRIMARY KEY(deal_id, user_id, emoji)
+    polarity reaction_polarity NOT NULL,
+    emoji_count INTEGER NOT NULL DEFAULT 0,
+    last_action_at TIMESTAMPTZ DEFAULT NOW(),
+    PRIMARY KEY(deal_id, user_id)
 );
+
+-- Aggregate counters per deal for fast reads
+CREATE TABLE deal_reaction_counters (
+    deal_id BIGINT PRIMARY KEY,
+    positive_total INTEGER DEFAULT 0,
+    negative_total INTEGER DEFAULT 0,
+    neutral_total INTEGER DEFAULT 0,
+    emoji_counts JSONB DEFAULT '{}'::JSONB,
+    deal_exists BOOLEAN DEFAULT TRUE
+);
+
+-- Time bucketed series for velocity (hourly buckets)
+CREATE TABLE deal_reaction_hourly_counters (
+    deal_id BIGINT,
+    bucket_start TIMESTAMPTZ,
+    positive_total INTEGER DEFAULT 0,
+    negative_total INTEGER DEFAULT 0,
+    neutral_total INTEGER DEFAULT 0,
+    emoji_counts JSONB DEFAULT '{}'::JSONB,
+    PRIMARY KEY(deal_id, bucket_start)
+);
+
+-- Derived trending scores per deal
+CREATE TABLE deal_scores (
+    deal_id BIGINT PRIMARY KEY,
+    hot_score NUMERIC(12,4) DEFAULT 0,
+    last_scored_at TIMESTAMPTZ,
+    is_hot BOOLEAN DEFAULT FALSE
+);
+
+-- Audit log for reaction mutations
+CREATE TYPE reaction_action AS ENUM ('add','remove','clear','switch');
+
+CREATE TABLE reaction_events (
+    id BIGSERIAL PRIMARY KEY,
+    deal_id BIGINT,
+    user_id BIGINT,
+    emoji TEXT,
+    action reaction_action NOT NULL,
+    reason TEXT,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Helpful indexes for hot paths
+CREATE UNIQUE INDEX reactions_idempotency_idx ON reactions(idempotency_key);
+CREATE UNIQUE INDEX reactions_user_deal_emoji_idx ON reactions(deal_id, user_id, emoji) WHERE deleted_at IS NULL;
+CREATE INDEX reactions_deal_idx ON reactions(deal_id);
+CREATE INDEX reactions_user_idx ON reactions(user_id);
+CREATE INDEX reactions_deal_created_idx ON reactions(deal_id, created_at);
+CREATE INDEX reactions_deal_emoji_idx ON reactions(deal_id, emoji);
+CREATE INDEX hourly_counters_idx ON deal_reaction_hourly_counters(deal_id, bucket_start);


### PR DESCRIPTION
## Summary
- define reaction catalog with emoji polarity, weights and activation flags
- track individual reaction events with context, per-user snapshots and per-deal counters
- document reaction tables and indexes for fast aggregation

## Testing
- `psql -v ON_ERROR_STOP=1 -f schemas/postgres/votes.sql` *(fails: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bfd667181c8330997abd624e46a162